### PR TITLE
Write reference files for 264 Tools modules

### DIFF
--- a/docs/refpages/264-ref/264.audio-presets.maxref.xml
+++ b/docs/refpages/264-ref/264.audio-presets.maxref.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.audio-presets" module="264 Tools" kind="patcher">
+
+	<digest>
+		Store and recall audio parameters in 264 Tools modules.
+	</digest>
+
+	<description>
+		Manages numbered presets containing	audio
+		parameters of other 264 Tools modules.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="int/float">
+			<digest>
+				Preset to be recalled
+			</digest>
+			<description>
+				Sets preset number to be recalled. Floats are interpreted as indexes (e.g. 2. = preset 2), integers are understood as MIDI with 0–127 mapped to 1–10. (Indexes greater than 10 are possible, but only accessible via float input.)
+			</description>
+		</inlet>
+		<inlet id="1" type="bang">
+			<digest>
+				Recall preset
+			</digest>
+			<description>
+				Recalls the preset chosen via the number box or first inlet.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Preset to be stored
+			</digest>
+			<description>
+				Sets preset number to be stored. Floats are interpreted as indexes (e.g. 2. = preset 2), integers are understood as MIDI with 0–127 mapped to 1–10. (Indexes greater than 10 are possible, but only accessible via float input.)
+			</description>
+		</inlet>
+		<inlet id="3" type="bang">
+			<digest>
+				Store preset
+			</digest>
+			<description>
+				Stores the preset chosen via the number box or first inlet.
+			</description>
+		</inlet>
+		<inlet id="4" type="int/float">
+			<digest>
+				Interpolate presets
+			</digest>
+			<description>
+				Interpolates between presets (using <o>pattrstorage</o>’s built-in interpolation). For example, an input of 1.5 will set any stored linear parameters to be halfway between their values for preset 1 and 2. Parameters that are on/off will simply toggle when a preset is reached.
+
+				Floats are interpreted as indexes (e.g. 2. = preset 2), integers are understood as MIDI with 0–127 mapped to 1–10.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.audio-presets</o> allows you to easily store and recall audio parameters in other 264 modules — provided that they have been given unique names as their first argument. The presets are stored as JSON files in a directory named audio-presets in the folder where your patch is saved.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.midi-presets" />
+		<seealso name="264.midi-learn" />
+		<seealso name="264.audiotest~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.audiotest~.maxref.xml
+++ b/docs/refpages/264-ref/264.audiotest~.maxref.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.audiotest~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Check audio set-up quickly with a graphical interface.
+	</digest>
+
+	<description>
+		Shows audio status, input and output levels, input and output devices,
+		and provides a quick noise test for loudspeakers.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools utilities</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+
+	<!--OUTLETS-->
+
+	<!--ARGUMENTS-->
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.audiotest~</o> allows you to quickly
+		troubleshoot common audio set-up problems. <o>264.audiotest~</o> clearly
+		shows whether DSP is currently turned on or off, and shows the input and
+		output levels of your patch for channels 1 and 2. While DSP is off, you can
+		also quickly select input and output devices. A speaker test allows you to
+		sends short bursts of white noise to channel 1, channel 2, or channels 1–8,
+		to quickly test whether your audio set-up is working.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.audio-presets" />
+		<seealso name="264.fullscreen" />
+		<seealso name="264.lockstatus" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.delay~.maxref.xml
+++ b/docs/refpages/264-ref/264.delay~.maxref.xml
@@ -115,6 +115,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.delay~.maxref.xml
+++ b/docs/refpages/264-ref/264.delay~.maxref.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.delay~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Apply a delay line to audio via a graphical interface.
+	</digest>
+
+	<description>
+		Combines delay with feedback and filtering
+		in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be processed
+			</digest>
+			<description>
+				Signal connected to the first outlet will have the delay effect applied.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Volume
+			</digest>
+			<description>
+				Sets the volume of the delay module’s output. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Delay length
+			</digest>
+			<description>
+				Sets the interval of the delay. Floats are understood as absolute values in seconds (0.–60). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Feedback amount
+			</digest>
+			<description>
+				Set how much the delay line feeds back into itself. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="4" type="int/float">
+			<digest>
+				Filter frequency
+			</digest>
+			<description>
+				Set the cut-off frequency of the feedback low-pass filter. Floats are understood as absolute values (0.–22.1) in kilohertz. Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="5" type="bang">
+			<digest>
+				Clear delay
+			</digest>
+			<description>
+				Clear the memory of the delay line. Helpful when using long delays.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Processed signal
+			</digest>
+			<description>
+				Signal with the delay effect applied.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.delay~</o> provides a graphical interface to control a delay effect with built-in feedback and filtering. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.delay~.maxref.xml
+++ b/docs/refpages/264-ref/264.delay~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.envelope~.maxref.xml
+++ b/docs/refpages/264-ref/264.envelope~.maxref.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.envelope~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Get amplitude data from an audio signal.
+	</digest>
+
+	<description>
+		Analyse an audio signal and output a continuous flow of
+		data about how loud it is using a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio analysis</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be analysed
+			</digest>
+			<description>
+				Signal connected to the first outlet will be analysed for its amplitude.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Gain
+			</digest>
+			<description>
+				Multiply the input signal to make it louder or quieter. Floats are
+				understood as absolute values (0.–4.). Integers are understood as a
+				MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Envelope sharpness
+			</digest>
+			<description>
+				Controls how quickly the analysis responds to changes in your signal’s
+				amplitude. Technically, this sets the cut-off frequency of a low-pass
+				filter used in the analysis algorithm. Floats are understood as absolute
+				values in kHz (0.0001–1.). Integers are understood as a MIDI range
+				(0–127) and mapped exponentially to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int">
+			<digest>
+				Invert on/off
+			</digest>
+			<description>
+				Turn the envelope inversion on or off. 0 = off; non-zero = on;
+				bang reverses the current state.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="int">
+			<digest>
+				Envelope control data
+			</digest>
+			<description>
+				Integers (0–127) representing the amplitude of the audio input are
+				output approximately every 25ms when DSP is turned on.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.envelope~</o> provides a graphical
+		interface to control an audio analysis tool returning information about the
+		amplitude of an audio input. Connect to your MIDI controller by clicking on
+		the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.trigger~" />
+		<seealso name="264.pitchtrack~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.envelope~.maxref.xml
+++ b/docs/refpages/264-ref/264.envelope~.maxref.xml
@@ -37,7 +37,8 @@
 			<description>
 				Multiply the input signal to make it louder or quieter. Floats are
 				understood as absolute values (0.–4.). Integers are understood as a
-				MIDI range (0–127) and mapped to the float range.
+				MIDI range (0–127) and mapped to the float range. Defaults to 1. (32),
+				i.e. no change in volume.
 			</description>
 		</inlet>
 		<inlet id="2" type="int/float">

--- a/docs/refpages/264-ref/264.filter~.maxref.xml
+++ b/docs/refpages/264-ref/264.filter~.maxref.xml
@@ -107,6 +107,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.filter~.maxref.xml
+++ b/docs/refpages/264-ref/264.filter~.maxref.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.filter~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Filter audio via a graphical interface.
+	</digest>
+
+	<description>
+		Apply a lowpass, highpass, bandpass, or bandstop
+		filter in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be filtered
+			</digest>
+			<description>
+				Signal connected to the first outlet will be filtered according to the module’s settings.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Filter frequency
+			</digest>
+			<description>
+				Sets the center or cut-off frequency of the filter. Floats are understood as absolute values in kHz (0.01–22.1). Integers are understood as a MIDI range (0–127) and mapped exponentially to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Filter Q
+			</digest>
+			<description>
+				Sets the filter’s Q factor (how tight the filter’s response is). Floats are understood as absolute values (0.01–10.). Integers are understood as a MIDI range (0–127) and mapped exponentially to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Filter type
+			</digest>
+			<description>
+				Select whether the module is a lowpass, highpass, bandpass, or bandstop filter. 0 = lowpass; 1 = highpass; 2 = bandpass; 3 = bandstop. Floats are truncated rather than rounded up/down, i.e. 1.8 = 1.
+			</description>
+		</inlet>
+		<inlet id="4" type="int">
+			<digest>
+				Bypass on/off
+			</digest>
+			<description>
+				Turn the filter bypass on or off. 0 = off; non-zero = on; bang reverses the current state.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Filtered signal
+			</digest>
+			<description>
+				Signal that has been filtered according to the module’s settings.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.filter~</o> provides a graphical interface to control an audio filter of various types. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.delay~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.filter~.maxref.xml
+++ b/docs/refpages/264-ref/264.filter~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.freeze~.maxref.xml
+++ b/docs/refpages/264-ref/264.freeze~.maxref.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.freeze~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Freeze audio via a graphical interface.
+	</digest>
+
+	<description>
+		Capture and freeze an audio input creating a continuous
+		sound with a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be “frozen”
+			</digest>
+			<description>
+				Signal connected to the first outlet will be captured in a short buffer on the freeze command.
+			</description>
+		</inlet>
+		<inlet id="1" type="bang">
+			<digest>
+				Trigger freeze
+			</digest>
+			<description>
+				A bang will trigger the capturing of the input audio and start outputting the “frozen” sound.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Volume
+			</digest>
+			<description>
+				Sets the volume of the freeze module’s output. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="bang">
+			<digest>
+				Clear freeze
+			</digest>
+			<description>
+				A bang will clear the memory of the freeze module, silencing output.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				“Frozen” signal
+			</digest>
+			<description>
+				Outputs signal generated from the spectrum of the input at the moment that the freeze was triggered.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.freeze~</o> provides a graphical interface to capture and output a “frozen” momentary audio spectrum. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.delay~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.freeze~.maxref.xml
+++ b/docs/refpages/264-ref/264.freeze~.maxref.xml
@@ -99,6 +99,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.freeze~.maxref.xml
+++ b/docs/refpages/264-ref/264.freeze~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.fullscreen.maxref.xml
+++ b/docs/refpages/264-ref/264.fullscreen.maxref.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.fullscreen" module="264 Tools" kind="patcher">
+
+	<digest>
+		Make a patch fill the whole screen.
+	</digest>
+
+	<description>
+		Toggle whether or not a patch is in fullscreen
+		mode using a graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools utilities</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="int">
+			<digest>
+				Toggle fullscreen
+			</digest>
+			<description>
+				1 sets patch display to fullscreen; 0 turns it off; bang reverses the current state.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="int">
+			<digest>
+				Display mode
+			</digest>
+			<description>
+				Current screen display mode. 0 = normal; 1 = fullscreen.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+
+	<!--MESSAGES-->
+	<methodlist>
+    <method name="bang">
+      <arglist/>
+      <digest>
+        Toggle display mode
+      </digest>
+      <description>
+        Reverses current screen display mode.
+      </description>
+    </method>
+    <method name="int">
+      <arglist>
+        <arg id="0" name="input" optional="0" type="int"/>
+      </arglist>
+      <digest/>
+      <description>
+        The number is sent out the outlet. If the number is not 0,
+				<o>264.fullscreen</o> switches patch display to fullscreen. If it is
+				<m>0</m>, <o>264.fullscreen</o> switches to normal display mode.
+      </description>
+    </method>
+  </methodlist>
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		<o>264.fullscreen</o> allows you to switch your patch to display in
+		fullscreen mode. When used in a <o>bpatcher</o>, a graphical interface
+		allows you to switch display modes with the mouse. Otherwise, the first
+		inlet of the object can be used to switch modes.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.lockstatus" />
+		<seealso name="264.audiotest~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.go!.maxref.xml
+++ b/docs/refpages/264-ref/264.go!.maxref.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.go!" module="264 Tools" kind="patcher">
+
+	<digest>
+		MIDI-ready button.
+	</digest>
+
+	<description>
+		A simple button to send bangs from your MIDI controller.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="bang">
+			<digest>
+				Trigger bang
+			</digest>
+			<description>
+				Any input causes the graphical button to flash and a <m>bang</m> to be output.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="bang">
+			<digest>
+				Bang
+			</digest>
+			<description>
+				Outputs a <m>bang</m> on input, click or MIDI button press (bang on 127).
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.go!</o> allows you to quickly link a MIDI controller button to your patch to trigger <m>bang</m>s.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.tog" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.grains~.maxref.xml
+++ b/docs/refpages/264-ref/264.grains~.maxref.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.grains~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Audio granulation via a graphical interface.
+	</digest>
+
+	<description>
+		Cut audio input into grains and control rate, size,
+		pitch, and volume with a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be granulated
+			</digest>
+			<description>
+				Signal connected to the first outlet will be captured and processed
+				into “grains”. The size, rate of output, pitch, and volume of these
+				grains can be controlled via the module’s inlets or graphical interface.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Grain rate
+			</digest>
+			<description>
+				Sets the interval at which a grain is output. Floats are understood as
+				absolute values in seconds (0.001–1.). Integers are understood as a MIDI
+				range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Grain rate variation
+			</digest>
+			<description>
+				Sets the range of random variation in the grain rate. Floats are
+				understood as a fraction of the grain rate (0.–1.). Integers are
+				understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Grain size
+			</digest>
+			<description>
+				Sets the duration of each grain. Floats are understood as absolute
+				values in seconds (0.005–10.). Integers are understood as a MIDI range
+				(0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="4" type="int/float">
+			<digest>
+				Grain size variation
+			</digest>
+			<description>
+				Sets the range of random variation in the grain size. Floats are
+				understood as a fraction of the grain size (0.–1.). Integers are
+				understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="5" type="int/float">
+			<digest>
+				Grain pitch
+			</digest>
+			<description>
+				Sets the pitch of each grain. Floats are understood in a range of
+				0.001–4. where 1. is equivalent to the original pitch, 2. is one octave
+				higher, and 0.5 is one octave lower. Integers are understood as a MIDI
+				range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="6" type="int/float">
+			<digest>
+				Grain pitch variation
+			</digest>
+			<description>
+				Sets the range of random variation in the grain pitch. Floats are
+				understood as a fraction of the grain pitch (0.–1.). Integers are
+				understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="7" type="int/float">
+			<digest>
+				Grain volume
+			</digest>
+			<description>
+				Sets the volume of each grain. Floats are understood as absolute values
+				(0.–1.). Integers are understood as a MIDI range (0–127) and mapped to
+				the float range.
+			</description>
+		</inlet>
+		<inlet id="8" type="int">
+			<digest>
+				Bypass on/off
+			</digest>
+			<description>
+				Turn a bypass on or off, temporarily disabling the granulator. 0 =
+				bypass off (granulation enabled); non-zero = bypass on (granulation
+				disabled); bang reverses the current state.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Granulated signal
+			</digest>
+			<description>
+				Outputs signal combining playback of all the grains processed from the input signal.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.grains~</o> provides a graphical interface to apply a granulation effect to any audio input. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.delay~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.grains~.maxref.xml
+++ b/docs/refpages/264-ref/264.grains~.maxref.xml
@@ -158,6 +158,7 @@
 		<seealso name="264.freeze~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.grains~.maxref.xml
+++ b/docs/refpages/264-ref/264.grains~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.limit~.maxref.xml
+++ b/docs/refpages/264-ref/264.limit~.maxref.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.limit~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Limit audio amplitude with graphical feedback.
+	</digest>
+
+	<description>
+		Limit the peaks of audio input to prevent clipping
+		or distortion and see visual feedback about the signal.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be limited
+			</digest>
+			<description>
+				Signal connected to the first outlet will be limited to between –1 and 1 to try to avoid audio clipping/distortion upon conversion to an analogue output.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Limited signal
+			</digest>
+			<description>
+				Signal between -1 and 1.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.limit~</o> provides a graphical interface that lights up red when peak limiting is active, giving you feedback about how your audio is being processed.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.filter~" />
+		<seealso name="264.reverb~" />
+		<seealso name="264.delay~" />
+		<seealso name="264.transpose~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.limit~.maxref.xml
+++ b/docs/refpages/264-ref/264.limit~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.lockstatus.maxref.xml
+++ b/docs/refpages/264-ref/264.lockstatus.maxref.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.lockstatus" module="264 Tools" kind="patcher">
+
+	<digest>
+		Check whether or not a patch is currently locked.
+	</digest>
+
+	<description>
+		Returns the current status of a patch (locked/unlocked)
+		and in a bpatcher displays the status graphically.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools utilities</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="bang">
+			<digest>
+				Get lock status
+			</digest>
+			<description>
+				Triggers output of current lock status.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="int">
+			<digest>
+				Lock status
+			</digest>
+			<description>
+				Current lock status. 0 = unlocked; 1 = locked.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+
+	<!--MESSAGES-->
+	<methodlist>
+    <method name="bang">
+      <arglist/>
+      <digest>
+        Get lock status
+      </digest>
+      <description>
+        Triggers output of current lock status.
+      </description>
+    </method>
+    <method name="active">
+      <arglist>
+        <arg id="0" name="status" optional="0" type="int"/>
+      </arglist>
+      <digest/>
+      <description>
+        Sets whether or not <o>264.lockstatus</o> outputs at regular intervals
+				(<m>active 1</m> or other non-zero integer argument) or only upon
+				receiving a <m>bang</m> (<m>active 0</m>).
+      </description>
+    </method>
+  </methodlist>
+
+	<!--ATTRIBUTES-->
+	<attributelist>
+		<attribute name="active" get="1" set="1" type="int" size="1">
+			<digest>
+				Output type
+			</digest>
+			<description>
+				Sets whether or not <o>264.lockstatus</o> outputs at regular intervals
+				(<m>active 1</m> or other non-zero integer argument) or only upon
+				receiving a <m>bang</m> (<m>active 0</m>).
+			</description>
+		</attribute>
+		<attributelist>
+			<attribute name="default" get="1" set="1" type="int" size="1" value="0" />
+		</attributelist>
+	</attributelist>
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		<o>264.lockstatus</o> allows you to check whether or not a patch is
+		currently locked. This can be useful, for example, when building keyboard
+		control systems and you need to disable your keyboard shortcuts while
+		editing your patch, i.e. when your patch is unlocked. A <m>bang</m> will
+		trigger output of the current status, or the <m>active</m> attribute can
+		be turned on for continuous polling.
+		Used in a <o>bpatcher</o>, <o>264.lockstatus</o> also provides a graphical
+		representation of the patch’s lock status.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.fullscreen" />
+		<seealso name="264.audiotest~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.loop~.maxref.xml
+++ b/docs/refpages/264-ref/264.loop~.maxref.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.loop~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Record and loop audio via a graphical interface.
+	</digest>
+
+	<description>
+		Record audio input into a buffer and loop it with various
+		playback controls in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio files</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+    <inlet id="0" type="signal">
+      <digest>
+        Audio to record
+      </digest>
+      <description>
+        Audio input to be recorded to the looper buffer.
+      </description>
+    </inlet>
+		<inlet id="1" type="message">
+			<digest>
+				Playback control messages
+			</digest>
+			<description>
+				<m>0</m> stops playback;
+				<m>1</m> starts playback;
+				<m>bang</m> reverses current state (i.e. if playing, stops it; if stopped, starts playing).
+			</description>
+		</inlet>
+		<inlet id="2" type="message">
+			<digest>
+				Record control messages
+			</digest>
+			<description>
+				<m>0</m> stops recording;
+				<m>1</m> starts recording;
+				<m>bang</m> reverses current state (i.e. if recording, stops; if not recording, starts).
+        N.B. recording can be started and stopped during playback, in which case
+        stopping recording does not interrupt playback.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Volume
+			</digest>
+			<description>
+				Sets the volume of buffer playback.
+				Floats are understood as absolute values in terms of amplitude (0.–1.).
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="4" type="int/float">
+			<digest>
+				Speed
+			</digest>
+			<description>
+				Set how fast the buffer is played back.
+				Floats are understood as absolute values (-4.–4.), e.g. <m>0.5</m> = half speed; <m>1.</m> = normal speed; <m>2.</m> = double speed.
+				Negative values play the loop backwards, e.g. <m>-2.</m> = double speed backwards.
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+    <inlet id="5" type="int/float">
+			<digest>
+				Position
+			</digest>
+			<description>
+				Set the position in the buffer to begin playback. If you are looping the
+        full duration of the buffer, this has no effect, but if you loop less than
+        the full duration (by setting a window smaller than <m>1.</m>), this will
+        control where the loop starts.
+				Floats are understood as absolute values (0.–1.).
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+    <inlet id="6" type="int/float">
+			<digest>
+				Window
+			</digest>
+			<description>
+				Set how much of the buffer is played back. By default this is set to <m>1.</m>
+        and <o>264.loop~</o> will loop the entire recorded buffer, i.e. 100%.
+        Smaller values will loop through only a part of the loop’s duration.
+				Floats are understood as absolute values (0.–1.).
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+    <inlet id="7" type="message">
+			<digest>
+				Jump control messages
+			</digest>
+			<description>
+				<m>jump 1/0</m> turns jumping behaviour on/off;
+				<m>constrain 1/0</m> sets whether jumping is constrained to the buffer window or not;
+				<m>rate float/int</m> sets how often the loop will jump to a new position (range: 0.004–10./0–127, where floats are understood as seconds);
+        <m>variation float/int</m> sets how much the jump rate varies (range: 0.–1./0–127, where floats are understood as a percentage of the rate).
+			</description>
+		</inlet>
+		<inlet id="8" type="symbol">
+			<digest>
+				Soundfile
+			</digest>
+			<description>
+				In addition to recording audio in the first inlet <o>264.loop~</o> can
+        load an existing soundfile from your hard drive. Doing so clears out any
+        content that the looper previously recorded. To load a file, your
+        message must match the name of an audio file in your soundfiles folder.
+        File names must include one of the following extensions: .wav; .wave;
+        .aif; or .aiff. File names should not include spaces. For best results
+        stick to upper- and lowercase letters, numbers, hyphens, and underscores.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Signal
+			</digest>
+			<description>
+				Looper buffer playback signal.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.loop~</o> provides a graphical interface
+    to record and playback an audio <o>buffer~</o>, including various controls
+    of volume, speed, loop position, loop size, and some more advanced playback
+    options. Connect to your MIDI controller by clicking on the
+    <o>264.midi-learn</o> arrows.
+    <o>264.loop~</o> is built around Rodrigo Constanzo and raja’s <o>karma~</o>
+    varispeed audio looper.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.sfrecord~" />
+		<seealso name="264.sfplay~" />
+		<seealso name="264.freeze~" />
+    <seealso name="karma~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.midi-presets.maxref.xml
+++ b/docs/refpages/264-ref/264.midi-presets.maxref.xml
@@ -82,6 +82,7 @@
 
 	<!--SEEALSO-->
 	<seealsolist>
+		<seealso name="264.audio-presets" />
 		<seealso name="264.midi-learn" />
 	</seealsolist>
 

--- a/docs/refpages/264-ref/264.pitchtrack~.maxref.xml
+++ b/docs/refpages/264-ref/264.pitchtrack~.maxref.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.pitchtrack~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Get pitch data from an audio signal.
+	</digest>
+
+	<description>
+		Analyse an audio signal and output a continuous flow of
+		data about its pitch content using a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio analysis</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be analysed
+			</digest>
+			<description>
+				Signal connected to the first outlet will be analysed for its pitch.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Sharpness
+			</digest>
+			<description>
+				Controls how quickly the analysis responds to changes in your signal’s
+				pitch. Floats and integers are understood as equivalent in a MIDI
+				range (0.–127./0–127).
+				At 127 the pitch-tracker will try to report new notes as fast as
+				possible, while at 0 notes can be triggered at most about eight times
+				per second.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Quality
+			</digest>
+			<description>
+				Controls the maximum number of frequency peaks analysed before deciding
+				a signal’s main pitch. Higher values may give better quality results,
+				but will also use more processing power.
+				Floats are understood as absolute values (0.–40.). Integers are
+				understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Relative pitch
+			</digest>
+			<description>
+				Only used in relative mode. This sets which pitch you want to analyse
+				relative to. For example, if set to Middle C, an analysed Middle D
+				would output 2, i.e. 2 semitones above your relative pitch.
+				Floats and integers are understood as equivalent, and use standard MIDI
+				pitch values (0.–127./0–127). For example: Middle C = 60; C an octave
+				below that = 48.
+			</description>
+		</inlet>
+		<inlet id="4" type="int">
+			<digest>
+				Pitch mode
+			</digest>
+			<description>
+				Toggle between “absolute” and “relative” modes. 0 = absolute; non-zero =
+				relative; bang reverses the current state.
+				In absolute mode, the pitch-tracker will return the analysed pitch in
+				standard MIDI pitch values (e.g. Middle C = 60). In relative mode, the
+				output value will be the number of semitones above or below the relative
+				pitch set in the module’s graphical interface or fourth inlet.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="int">
+			<digest>
+				Pitch as control data
+			</digest>
+			<description>
+				Integers (0–127) representing the pitch of the audio input are
+				output every time a note is detected.
+				In absolute mode, the pitch-tracker will return the analysed pitch in
+				standard MIDI pitch values (e.g. Middle C = 60). In relative mode, the
+				output value will be the number of semitones above or below the relative
+				pitch set in the module’s graphical interface or fourth inlet.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.pitchtrack~</o> provides a graphical
+		interface to control an audio analysis tool returning information about the
+		pitch of an audio input. Connect to your MIDI controller by clicking on
+		the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.trigger~" />
+		<seealso name="264.envelope~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.reverb~.maxref.xml
+++ b/docs/refpages/264-ref/264.reverb~.maxref.xml
@@ -115,6 +115,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.reverb~.maxref.xml
+++ b/docs/refpages/264-ref/264.reverb~.maxref.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.reverb~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Apply a reverb effect to audio via a graphical interface.
+	</digest>
+
+	<description>
+		Flexible reverb module with brightness, length, size, and
+		dry/wet balance in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be processed
+			</digest>
+			<description>
+				Signal connected to the first outlet will have the reverb effect applied.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Dry Volume
+			</digest>
+			<description>
+				Sets the volume of the reverb module’s “dry” (non-reverb) output. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Wet volume
+			</digest>
+			<description>
+				Sets the volume of the reverb module’s “wet” (reverbed) output. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Plate size
+			</digest>
+			<description>
+				Sets the size of the plate being modelled. Cannot be changed while playing back without clicks. Floats are understood as absolute values (0.01–1.6). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="4" type="int/float">
+			<digest>
+				Feedback amount
+			</digest>
+			<description>
+				Sets the amount of feedback in the system, effectively controlling the reverb length. Floats are understood as absolute values (0.05–0.9). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="5" type="bang">
+			<digest>
+				Lowpass frequency
+			</digest>
+			<description>
+				Sets the cut-off frequency of a low-pass filter. Sometimes referred to as the “damping” frequency. Higher values give a brighter sound, while lower values limit the reverb to lower frequencies. Floats are understood as absolute values (0.02–12.) in kilohertz. Integers are understood as a MIDI range (0–127) and mapped exponentially to the float range.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Processed signal
+			</digest>
+			<description>
+				Signal with the reverb effect applied.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.reverb~</o> provides a graphical interface to control a reverb effect with various controllable parameters. The processing models a plate reverb with feedback and filtering, based on Randy Jones’s <o>yafr2</o>. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.delay~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.reverb~.maxref.xml
+++ b/docs/refpages/264-ref/264.reverb~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.ringmod~.maxref.xml
+++ b/docs/refpages/264-ref/264.ringmod~.maxref.xml
@@ -99,6 +99,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.filter~" />
 		<seealso name="264.transpose~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.ringmod~.maxref.xml
+++ b/docs/refpages/264-ref/264.ringmod~.maxref.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.ringmod~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Ring modulate audio via a graphical interface.
+	</digest>
+
+	<description>
+		Apply a ring modulation effect, varying strength and
+		carrier frequency, with a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be modulated
+			</digest>
+			<description>
+				Signal connected to the first outlet will modulated by an internal sine wave.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Modulation frequency
+			</digest>
+			<description>
+				Sets the frequency of the modulating sine wave. Floats are understood as absolute values in kHz (0.001–2.). Integers are understood as a MIDI range (0–127) and mapped exponentially to the float range.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Modulation strength
+			</digest>
+			<description>
+				Controls how much the modulation affects the input signal. Floats are understood as absolute values (0.–1.) where 0. has no effect, and 1. is full strength. Integers are understood as a MIDI range (0–127) and mapped linearly to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Output volume
+			</digest>
+			<description>
+				Sets the volume of the ring modulation module’s output. Floats are understood as absolute values (0.–1.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Modulated signal
+			</digest>
+			<description>
+				Signal that has been ring modulated according to the module’s settings.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.ringmod~</o> provides a graphical interface to control ring modulation with a sinusoidal oscillator. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.delay~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.transpose~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.ringmod~.maxref.xml
+++ b/docs/refpages/264-ref/264.ringmod~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.sfplay~.maxref.xml
+++ b/docs/refpages/264-ref/264.sfplay~.maxref.xml
@@ -17,7 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
-		<metadata name="tag">264 Tools audio playback</metadata>
+		<metadata name="tag">264 Tools audio files</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.sfplay~.maxref.xml
+++ b/docs/refpages/264-ref/264.sfplay~.maxref.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.sfplay~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Load and play soundfiles from disk via a graphical interface.
+	</digest>
+
+	<description>
+		Combines soundfile loading, playback, volume,
+		and speed controls in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio playback</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="message">
+			<digest>
+				Playback control messages
+			</digest>
+			<description>
+				<m>0</m> stops playback;
+				<m>1</m> starts playback (from beginning of file);
+				<m>bang</m> reverses current state (i.e. if playing, stops it; if stopped, starts playing);
+				<m>loop 1/0</m> turns playback looping on/off.
+			</description>
+		</inlet>
+		<inlet id="1" type="message">
+			<digest>
+				Pause control
+			</digest>
+			<description>
+				<m>0</m> pauses playback;
+				<m>1</m> unpauses playback;
+				<m>bang</m> reverses current state (i.e. if playing, pauses it; if paused, unpauses).
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Volume
+			</digest>
+			<description>
+				Sets the volume of soundfile playback.
+				Floats are understood as absolute values in terms of amplitude (0.–1.).
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Speed
+			</digest>
+			<description>
+				Set how fast the file is played back.
+				Floats are understood as absolute values (-4.–4.), e.g. <m>0.5</m> = half speed; <m>1.</m> = normal speed; <m>2.</m> = double speed.
+				Negative values play the file backwards, e.g. <m>-2.</m> = double speed backwards.
+				Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+		<inlet id="4" type="symbol">
+			<digest>
+				Soundfile
+			</digest>
+			<description>
+				Sets which file should be played back. Must match the name of an audio
+				file in your soundfiles folder. File names must include one of the
+				following extensions: .wav; .wave; .aif; or .aiff. File names should not
+				include spaces. For best results stick to upper- and lowercase letters,
+				numbers, hyphens, and underscores.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Signal
+			</digest>
+			<description>
+				Soundfile playback signal.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<!-- <objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist> -->
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.sfplay~</o> provides a graphical interface to load and play soundfiles from your hard drive, including controls for volume and speed. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.sfrecord~" />
+		<seealso name="264.loop~" />
+		<seealso name="264.freeze~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.sfrecord~.maxref.xml
+++ b/docs/refpages/264-ref/264.sfrecord~.maxref.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.sfrecord~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Record soundfiles to disk via a graphical interface.
+	</digest>
+
+	<description>
+		Easily record mono soundfiles and save them to disk
+    in a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio files</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to record
+			</digest>
+			<description>
+				Audio input that will be recorded to disk.
+			</description>
+		</inlet>
+		<inlet id="1" type="message">
+			<digest>
+				Record control
+			</digest>
+			<description>
+				<m>0</m> stops recording;
+				<m>1</m> (or other non-zero) starts recording;
+				<m>bang</m> reverses current state (i.e. if recording, stops it; if stopped, starts recording).
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Volume
+			</digest>
+			<description>
+				Sets the volume of the input audio.
+				Floats are understood as absolute values in dB (-70.–12.).
+				Integers are understood as a MIDI range (0–127) and mapped logarithmically to the float range.
+			</description>
+		<inlet id="3" type="symbol">
+			<digest>
+				Filename
+			</digest>
+			<description>
+				Sets the name your file will be saved to. Audio extensions (e.g.
+				<m>.wav</m>) will be stripped. Any non-alphanumeric character will
+				be replaced by a hyphen, e.g. an input of <m>±!@A£$%^&*()_+</m> will be
+				saved as <m>---A--------_-</m>. All audio files are saved to your
+				soundfiles folder.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+
+	<!--ARGUMENTS-->
+	<!-- <objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist> -->
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.sfrecord~</o> provides a graphical interface to easily record a mono soundfile to your hard drive. <o>264.sfrecord~</o> saves files to your patch’s soundfiles folder, allowing for easy use later with <o>264.sfplay~</o>. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.sfplay~" />
+		<seealso name="264.loop~" />
+		<seealso name="264.freeze~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.tog.maxref.xml
+++ b/docs/refpages/264-ref/264.tog.maxref.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object kind="patcher" module="264 Tools" name="264.tog">
+
+  <digest>
+    MIDI-ready toggle.
+  </digest>
+
+  <description>
+    A simple <o>toggle</o> extension to switch between <m>0</m> and <m>1</m> from your MIDI controller.
+  </description>
+
+  <!--METADATA-->
+  <metadatalist>
+    <metadata name="author">Chris Swithinbank</metadata>
+    <metadata name="tag">264 Tools</metadata>
+    <metadata name="tag">264 Tools abstractions</metadata>
+  </metadatalist>
+
+  <!--INLETS-->
+  <inletlist>
+    <inlet id="0">
+      <digest>
+        Toggle
+      </digest>
+      <description>
+        An integer sets the state of the toggle: zero = off; non-zero = on. A <m>bang</m> will reverse the current state.
+      </description>
+    </inlet>
+  </inletlist>
+
+  <!--OUTLETS-->
+  <outletlist>
+    <outlet id="0" type="int">
+      <digest>
+        Toggle state (1/0)
+      </digest>
+      <description>
+        Outputs the current toggle state (1 or 0) whenever it is changed.
+      </description>
+    </outlet>
+  </outletlist>
+
+  <!--ARGUMENTS-->
+  <objarglist>
+    <objarg name="unique id" optional="0" type="symbol">
+      <digest>
+        Unique identifier
+      </digest>
+      <description>
+        A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+      </description>
+    </objarg>
+  </objarglist>
+
+  <!--MESSAGES-->
+  <methodlist>
+    <method name="bang">
+      <arglist/>
+      <digest>
+        Switches <o>264.tog</o> on if it is off; switches it off if it is on.
+      </digest>
+      <description>
+        Switches <o>264.tog</o> on if it is off; switches it off if it is on.
+      </description>
+    </method>
+    <method name="int">
+      <arglist>
+        <arg id="0" name="input" optional="0" type="int"/>
+      </arglist>
+      <digest/>
+      <description>
+        The number is sent out the outlet. If the number is not 0, <o>264.tog</o> displays a cross, showing it is on. If it is <m>0</m>, <o>toggle</o> is blank, showing it is off.
+      </description>
+    </method>
+    <method name="float">
+      <arglist>
+        <arg id="0" name="input" optional="0" type="float"/>
+      </arglist>
+      <digest>
+        Converted to <m>int</m>.
+      </digest>
+      <description>
+        Converted to <m>int</m>.
+      </description>
+    </method>
+  </methodlist>
+
+  <!--ATTRIBUTES-->
+
+  <!--EXAMPLE-->
+
+  <!--DISCUSSION-->
+  <discussion>
+    Used in a <o>bpatcher</o>, <o>264.tog</o> allows you to quickly link a MIDI controller button to your patch to toggle between <m>1</m> and <m>0</m>.
+  </discussion>
+
+  <!--SEEALSO-->
+  <seealsolist>
+    <seealso name="264.go!"/>
+  </seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.transpose~.maxref.xml
+++ b/docs/refpages/264-ref/264.transpose~.maxref.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.transpose~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Transpose audio via a graphical interface.
+	</digest>
+
+	<description>
+		Transpose audio up or down in pitch
+		using a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be transposed
+			</digest>
+			<description>
+				Signal connected to the first outlet will be transposed up or down in pitch.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Transposition amount
+			</digest>
+			<description>
+				Sets the number of semitones by which the audio input is transposed (up to three octaves in either direction). Floats are understood as absolute values (-36.–36.). Integers are understood as a MIDI range (0–127) and mapped to the float range.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="signal">
+			<digest>
+				Transposed signal
+			</digest>
+			<description>
+				Signal with the transposition applied.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.transpose~</o> provides a graphical interface to control transposition of incoming audio based on the <o>gizmo~</o> FFT pitch shifter. Connect to your MIDI controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.reverb~" />
+		<seealso name="264.filter~" />
+		<seealso name="264.freeze~" />
+		<seealso name="264.grains~" />
+		<seealso name="264.ringmod~" />
+		<seealso name="264.delay~" />
+	</seealsolist>
+
+</c74object>

--- a/docs/refpages/264-ref/264.transpose~.maxref.xml
+++ b/docs/refpages/264-ref/264.transpose~.maxref.xml
@@ -83,6 +83,7 @@
 		<seealso name="264.grains~" />
 		<seealso name="264.ringmod~" />
 		<seealso name="264.delay~" />
+		<seealso name="264.limit~" />
 	</seealsolist>
 
 </c74object>

--- a/docs/refpages/264-ref/264.transpose~.maxref.xml
+++ b/docs/refpages/264-ref/264.transpose~.maxref.xml
@@ -17,6 +17,7 @@
 		<metadata name="author">Chris Swithinbank</metadata>
 		<metadata name="tag">264 Tools</metadata>
 		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio processing</metadata>
 	</metadatalist>
 
 	<!--INLETS-->

--- a/docs/refpages/264-ref/264.trigger~.maxref.xml
+++ b/docs/refpages/264-ref/264.trigger~.maxref.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href="./_c74_ref.xsl" type="text/xsl"?>
+
+<c74object name="264.trigger~" module="264 Tools" kind="patcher">
+
+	<digest>
+		Trigger events with attacks in an audio signal.
+	</digest>
+
+	<description>
+		Analyse an audio signal for amplitude attacks and output bangs if
+		an attack passes a threshold using a simple graphical interface.
+	</description>
+
+	<!--METADATA-->
+	<metadatalist>
+		<metadata name="author">Chris Swithinbank</metadata>
+		<metadata name="tag">264 Tools</metadata>
+		<metadata name="tag">264 Tools abstractions</metadata>
+		<metadata name="tag">264 Tools audio analysis</metadata>
+	</metadatalist>
+
+	<!--INLETS-->
+	<inletlist>
+		<inlet id="0" type="signal">
+			<digest>
+				Audio to be analysed
+			</digest>
+			<description>
+				Signal connected to the first outlet will be analysed for its amplitude to detect attacks.
+			</description>
+		</inlet>
+		<inlet id="1" type="int/float">
+			<digest>
+				Gain
+			</digest>
+			<description>
+				Multiply the input signal to make it louder or quieter. Floats are
+				understood as absolute values (0.–4.). Integers are understood as a
+				MIDI range (0–127) and mapped to the float range. Defaults to 1. (32),
+				i.e. no change in volume.
+			</description>
+		</inlet>
+		<inlet id="2" type="int/float">
+			<digest>
+				Threshold
+			</digest>
+			<description>
+				Sets the threshold that must be passed for an attack to trigger a bang.
+				Floats are understood as absolute values (0.01–1.). Integers are
+				understood as a MIDI range (0–127) and mapped exponentially to the
+				float range.
+			</description>
+		</inlet>
+		<inlet id="3" type="int/float">
+			<digest>
+				Time gate
+			</digest>
+			<description>
+				Sets the amount of time that the envelope must fall below the threshold
+				before a new bang can be triggered. For example, if there are regular
+				attacks in your audio every 400ms and the time gate is set to 500ms,
+				only the first attack will trigger a bang, because each subsequent
+				attack will keep the time gate closed.
+				Floats are understood as absolute values in milliseconds (50.–5000.).
+				Integers are understood as a MIDI range (0–127) and mapped exponentially
+				to the float range.
+			</description>
+		</inlet>
+	</inletlist>
+
+	<!--OUTLETS-->
+	<outletlist>
+		<outlet id="0" type="bang">
+			<digest>
+				Attack trigger
+			</digest>
+			<description>
+				A bang is output for each detected attack that doesn’t take place while
+				the time gate is closed.
+			</description>
+		</outlet>
+	</outletlist>
+
+	<!--ARGUMENTS-->
+	<objarglist>
+		<objarg name="unique id" optional="0" type="symbol">
+			<digest>
+				Unique identifier
+			</digest>
+			<description>
+				A unique name allows the module to communicate with the 264 Tools preset mechanisms.
+			</description>
+		</objarg>
+	</objarglist>
+
+	<!--MESSAGES-->
+
+	<!--ATTRIBUTES-->
+
+	<!--EXAMPLE-->
+
+	<!--DISCUSSION-->
+	<discussion>
+		Used in a <o>bpatcher</o>, <o>264.trigger~</o> provides a graphical
+		interface to control an audio analysis tool returning bangs when an audio
+		input contains attacks above a set threshold. Connect to your MIDI
+		controller by clicking on the <o>264.midi-learn</o> arrows.
+	</discussion>
+
+	<!--SEEALSO-->
+	<seealsolist>
+		<seealso name="264.envelope~" />
+		<seealso name="264.pitchtrack~" />
+	</seealsolist>
+
+</c74object>


### PR DESCRIPTION
Adds `.maxref.xml` files for the following modules:

## Control
- `264.go!`
- `264.tog`
#### Presets
- `264.audio-presets`
- `264.midi-presets`
- `264.midi-learn`
#### Utility
- `264.fullscreen`
- `264.lockstatus`
## Audio
#### Processing
- `264.delay~`
- `264.filter~`
- `264.freeze~`
- `264.grains~`
- `264.limit~`
- `264.reverb~`
- `264.ringmod~`
- `264.transpose~`
#### Analysis
- `264.envelope~`
- `264.trigger~`
- `264.pitchtrack~`
#### Sound Files
- `264.sfplay~`
- `264.sfrecord~`
- `264.loop~`
#### Utility
- `264.audiotest~`